### PR TITLE
Add example usage via `pystow`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # data-sets
-| File                                 | N       | Source                                                   | Fingerprint | Format | Usage                                 |
-|--------------------------------------|---------|----------------------------------------------------------|-------------|--------|---------------------------------------|
-| ChEBI_complete-id_smiles_mhfp.pkl.gz | 145,893 | [ChEBI](https://www.ebi.ac.uk/chebi/downloadsForward.do) | MHFP        | pkl.gz | `ids, smiles, fps = pickle.load(...)` |
+
+| File                                 | N       | Source                                                   | Fingerprint | Format | Usage                                 | [PyStow](https://github.com/cthoyt/pystow) Usage                                                                                                                       |
+|--------------------------------------|---------|----------------------------------------------------------|-------------|--------|---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ChEBI_complete-id_smiles_mhfp.pkl.gz | 145,893 | [ChEBI](https://www.ebi.ac.uk/chebi/downloadsForward.do) | MHFP        | pkl.gz | `ids, smiles, fps = pickle.load(...)` | `ids, smiles, fps = pystow.ensure_pickle_gz("daenuprobst", "data-sets", url="https://github.com/daenuprobst/data-sets/raw/main/ChEBI_complete-id_smiles_mhfp.pkl.gz")` |


### PR DESCRIPTION
I've been building [`pystow`](https://github.com/cthoyt/pystow) for a while now to support reproducible acquisition and storage of data (i.e., taking care of putting data in a platform/user-agnostic folder with a deterministic name). This PR adds an example of the Python code it takes to get the data from GitHub, open it properly using `gzip`, and load it with `pickle` that works exactly the same on all systems.

You can see how the changes to the README are rendered here: https://github.com/cthoyt/daenuprobst-datasets/tree/pystow-docs#data-sets